### PR TITLE
Fix gain error

### DIFF
--- a/src/client/julia/Project.toml
+++ b/src/client/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "RedPitayaDAQServer"
 uuid = "c544963a-496b-56d4-a5fe-f99a3f174c8f"
 authors = ["Tobias Knopp <tobias@knoppweb.de>"]
-version = "0.7.0"
+version = "0.8.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/client/julia/src/ADC.jl
+++ b/src/client/julia/src/ADC.jl
@@ -97,6 +97,10 @@ julia> decimation(rp)
 ```
 """
 function decimation!(rp::RedPitaya, dec)
+  if dec < 8 || dec > 8192 || mod(dec, 2) != 0
+    error("Decimation must be an even value between 8 and 8192. Supplied value is $dec.")
+  end
+
   rp.decimation = Int64(dec)
   return query(rp, scpiCommand(decimation!, rp.decimation), scpiReturn(decimation!))
 end

--- a/src/client/julia/src/Cluster.jl
+++ b/src/client/julia/src/Cluster.jl
@@ -49,15 +49,16 @@ function RedPitayaCluster(hosts::Vector{String}, port::Int64=5025, dataPort::Int
     modes = fill(INTERNAL, length(rps))
     modes[1] = EXTERNAL
   end
-  @sync for (i, rp) in enumerate(rps)
-    @async begin 
+
+  @sync for (i, rp) ∈ enumerate(rps)
+    @async begin
       triggerMode!(rp, modes[i])
       triggerPropagation!(rp, true)
     end
   end
 
   triggerPropagation!(rps[end], false)
-  
+
   return RedPitayaCluster(rps)
 end
 

--- a/src/fpga/bd/bd.tcl
+++ b/src/fpga/bd/bd.tcl
@@ -1576,7 +1576,7 @@ proc create_hier_cell_system_1 { parentCell nameHier } {
   # Create instance: image_version, and set properties
   set image_version [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 image_version ]
   set_property -dict [ list \
-   CONFIG.CONST_VAL {7} \
+   CONFIG.CONST_VAL {8} \
    CONFIG.CONST_WIDTH {32} \
  ] $image_version
 

--- a/src/lib/rp-daq-lib.c
+++ b/src/lib/rp-daq-lib.c
@@ -540,6 +540,10 @@ int setArbitraryWaveform(float* values, int channel) {
 // Fast ADC
 
 int setDecimation(uint16_t decimation) {
+	if(!(decimation % 2 == 0)) {
+		return -1;
+	}
+
 	if(decimation < 8 || decimation > 8192) {
 		return -1;
 	}


### PR DESCRIPTION
A compensation for the gain change by the CIC was missing. This results in different scalings when changing decimations.

The result for a simple DC offset looks then like the following picture:
![Bild](https://github.com/user-attachments/assets/02f21630-d023-4108-8fb7-f8a85a86f03f)

A fix is described in https://support.xilinx.com/s/question/0D52E00006hpfy6SAA/cic-filter-gain?language=en_US. I added this fix to the application of the calibration in the client. The raw data from the server is thus not corrected. This is intended since at that point we are still working with integers. Only after calibration we get floatinbg point numbers.

@jusack Please check if this solves your problem.
@nHackel Could you please create a new release?